### PR TITLE
Fix bug when path is too long

### DIFF
--- a/modules/onlyfans.py
+++ b/modules/onlyfans.py
@@ -219,9 +219,9 @@ def reformat(directory2, file_name2, text, ext, date, username):
     path = path.replace("{ext}", ext)
     directory2 += path
     count_string = len(directory2)
-    if count_string > 260:
-        num_sum = count_string - 260
-        directory2 = directory2.replace(text, text[:-num_sum])
+    if count_string > 259:
+        num_sum = count_string - 259
+        directory2 = directory2.replace(filtered_text, filtered_text[:-num_sum])
 
     return directory2
 


### PR DESCRIPTION
Found 2 issues when handling a too long filename on Windows.

1) Wrong variable was being used for replacing with a shorter string

2) I can't explain this one, but I was getting a FileNotFound exception if the string was exactly 260 characters long, but 259 goes through with success.