### PR TITLE
Update default date format to YYYY-MM-DD

### DIFF
--- a/config.json
+++ b/config.json
@@ -21,7 +21,7 @@
         "file_name_format": "{file_name}.{ext}",
         "text_length": "",
         "overwrite_files": true,
-        "date_format": "%d-%m-%Y",
+        "date_format": "%Y-%m-%d",
         "ignored_keywords": []
       }
     },


### PR DESCRIPTION
Applying YYYY-MM-DD as a date format means that when it is applied, directories sorted by filename will display files in chronological order, as opposed to ordering by day of month first. This creates a more sensible default sort order for users who care about ease of chronological lookup.