### PR TITLE
Add exit on completion and loop timeout settings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,11 +137,24 @@ multithreading:
     If set to false, you will download files 1 by 1. (If you don't have fast internet, may god help you.)
     I'd reccomend leaving it set to true.
 
+exit_on_completion:
+
+    Default = false
+
+    If set to true the scraper run once and exit upon completion, otherwise the scraper will give the option to run again. This is useful if the scraper is being executed by a cron job or another script.
+
 infinite_loop:
 
     Default = true
 
     If set to false, the script will run once and ask you to input anything to continue.
+
+loop_timeout:
+
+    Default = 0
+
+    When infinite_loop is set to true this will set the time in seconds to pause the loop in between runs. 
+
 
 boards:
 

--- a/StartDatascraper.py
+++ b/StartDatascraper.py
@@ -9,6 +9,7 @@ import logging
 import traceback
 import inspect
 import os
+import time
 
 # Configure logging to the console and file system at INFO level and above
 logging.basicConfig(handlers=[logging.FileHandler('application.log', 'w', 'utf-8')], level=logging.INFO,
@@ -29,6 +30,8 @@ global_user_agent = json_settings['global_user-agent']
 domain = json_settings["auto_site_choice"]
 path = os.path.join('settings', 'extra_auth.json')
 extra_auth_config = json.load(open(path))
+exit_on_completion = json_settings['exit_on_completion']
+loop_timeout = json_settings['loop_timeout']
 
 string = ""
 site_names = []
@@ -150,9 +153,15 @@ try:
                 x.download_media(*arg)
         stop_time = str(int(timeit.default_timer() - start_time) / 60)
         print('Task Completed in ' + stop_time + ' Minutes')
-        if not infinite_loop:
+        if exit_on_completion:
+            print("Now exiting.")
+            exit(0)       
+        elif not infinite_loop:
             print("Input anything to continue")
             input()
+        elif loop_timeout:
+            print('Pausing scraper for ' + loop_timeout + ' seconds.')
+            time.sleep(int(loop_timeout))
 except Exception as e:
     tb = traceback.format_exc()
     print(tb+"\n")

--- a/settings/config.json
+++ b/settings/config.json
@@ -3,7 +3,9 @@
     "auto_site_choice": "",
     "export_type": "json",
     "multithreading": true,
+    "exit_on_completion": false,
     "infinite_loop": true,
+    "loop_timeout": "",
     "global_user-agent": ""
   },
   "supported": {

--- a/settings/config.json
+++ b/settings/config.json
@@ -5,7 +5,7 @@
     "multithreading": true,
     "exit_on_completion": false,
     "infinite_loop": true,
-    "loop_timeout": "",
+    "loop_timeout": "0",
     "global_user-agent": ""
   },
   "supported": {


### PR DESCRIPTION
Added the following configuration options.

exit_on_completion:
If set to true the scraper run once and exit upon completion, otherwise the scraper will give the option to run again. This is useful if the scraper is being executed by a cron job or another script.

loop_timeout:
When infinite_loop is set to true this will set the time in seconds to pause the loop in between runs. This should hopefully prevent any throttling or account suspension from constantly running this script in a loop. 


