### PR TITLE
Better handling of partial downloads

### DIFF
--- a/modules/helpers.py
+++ b/modules/helpers.py
@@ -175,6 +175,29 @@ def check_for_dupe_file(download_path, content_length):
     return found
 
 
+def download_to_file(request, download_path):
+    partial_path = download_path + ".part"
+
+    try:
+        os.unlink(partial_path)
+    except FileNotFoundError:
+        pass
+
+    delete = False
+    try:
+        with open(partial_path, 'xb') as f:
+            delete = True
+            for chunk in request.iter_content(chunk_size=1024):
+                if chunk:  # filter out keep-alive new chunks
+                    f.write(chunk)
+    except:
+        if delete:
+            os.unlink(partial_path)
+        raise
+    else:
+        os.replace(partial_path, download_path)
+
+
 def json_request(session, link, method="GET", stream=False, json_format=True):
     count = 0
     while count < 11:

--- a/modules/onlyfans.py
+++ b/modules/onlyfans.py
@@ -1,5 +1,5 @@
 import requests
-from modules.helpers import get_directory, json_request, reformat, format_directory, format_media_set, export_archive, format_image, check_for_dupe_file, setup_logger
+from modules.helpers import get_directory, json_request, reformat, format_directory, format_media_set, export_archive, format_image, check_for_dupe_file, setup_logger, download_to_file
 
 import os
 import json
@@ -419,10 +419,7 @@ def download_media(media_set, session, directory, username, post_count, location
             if not r:
                 return False
             try:
-                with open(download_path, 'wb') as f:
-                    for chunk in r.iter_content(chunk_size=1024):
-                        if chunk:  # filter out keep-alive new chunks
-                            f.write(chunk)
+                download_to_file(r, download_path)
             except (ConnectionResetError) as e:
                 log_error.exception(e)
                 count += 1


### PR DESCRIPTION
Always delete a partially-downloaded file on failure.

Also, download files with a `.part` extension and move it in place on success. This is what other downloaders like youtube-dl do.

Put the download code in an helper function in hope that it can end up being used in the other modules as well.

Also added a `return False` on other exceptions, sometimes it gets a connection error that does not get caught by the `except (ConnectionResetError):` and it crashes the whole thing.