### PR TITLE
Delete partial files on download failure

### DIFF
--- a/modules/onlyfans.py
+++ b/modules/onlyfans.py
@@ -418,18 +418,22 @@ def download_media(media_set, session, directory, username, post_count, location
             r = json_request(session, link, "GET", True, False)
             if not r:
                 return False
+            delete = False
             try:
                 with open(download_path, 'wb') as f:
+                    delete = True
                     for chunk in r.iter_content(chunk_size=1024):
                         if chunk:  # filter out keep-alive new chunks
                             f.write(chunk)
             except (ConnectionResetError) as e:
-                os.unlink(download_path)
+                if delete:
+                    os.unlink(download_path)
                 log_error.exception(e)
                 count += 1
                 continue
             except Exception as e:
-                os.unlink(download_path)
+                if delete:
+                    os.unlink(download_path)
                 log_error.exception(str(e) + "\n Tries: "+str(count))
                 count += 1
                 input("Enter to continue")

--- a/modules/onlyfans.py
+++ b/modules/onlyfans.py
@@ -424,10 +424,12 @@ def download_media(media_set, session, directory, username, post_count, location
                         if chunk:  # filter out keep-alive new chunks
                             f.write(chunk)
             except (ConnectionResetError) as e:
+                os.unlink(download_path)
                 log_error.exception(e)
                 count += 1
                 continue
             except Exception as e:
+                os.unlink(download_path)
                 log_error.exception(str(e) + "\n Tries: "+str(count))
                 count += 1
                 input("Enter to continue")


### PR DESCRIPTION
This is the simple version of partial file cleanup. It deletes partial files on failure.

Modified from the original to only delete if file was successfully created, otherwise it would except trying to handle the exception.