### PR TITLE
Fix shebang

### DIFF
--- a/start_ofd.py
+++ b/start_ofd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import tests.main_test as main_test
 
 main_test.version_check()


### PR DESCRIPTION
This script requires python 3. On most Linux distributions 'python' is a symlink to python 2. The only exception I'm aware of is Arch, which symlinks to python 3 instead. Luckily a more specific 'python3' is available on all distributions.

Fixes './start_ofd.py' on Ubuntu and other Linux distributions.