### PR TITLE
Resolve a leading '~' in the configured directory

### DIFF
--- a/helpers/main_helper.py
+++ b/helpers/main_helper.py
@@ -146,6 +146,7 @@ def export_archive(datas, archive_directory):
 
 def get_directory(directory):
     if directory:
+        directory = os.path.expanduser(directory)
         os.makedirs(directory, exist_ok=True)
         return directory
     else:


### PR DESCRIPTION
On Linux systems '~' commonly refers to the current user's home directory. Honor this for the configured directory path.

Fixes https://github.com/DIGITALCRIMINAL/OnlyFans/issues/251