### PR TITLE
Rename and redownload everthing with {media_id}

### DIFF
--- a/classes/prepare_metadata.py
+++ b/classes/prepare_metadata.py
@@ -8,6 +8,7 @@ def valid_invalid(item):
         class Item():
             def __init__(self, option={}):
                 self.post_id = option.get("post_id", None)
+                self.media_id = option.get("media_id", None)
                 self.links = option.get("links", [])
                 self.price = option.get("price", None)
                 self.text = option.get("text", "")

--- a/extras/OFRenamer/classes/prepare_metadata.py
+++ b/extras/OFRenamer/classes/prepare_metadata.py
@@ -7,6 +7,7 @@ def valid_invalid(item):
         class Item():
             def __init__(self, option={}):
                 self.post_id = option.get("post_id", None)
+                self.media_id = option.get("media_id", None)
                 if "link" in option:
                     option["links"] = [option["link"]]
                 self.links = option.get("links", [])


### PR DESCRIPTION
I have the Problem, that everthing renamed and redownloeded with media_id in dataname.

The first run is fine. Any media_id in the name will be removed and downloaded again.

Config:
"file_name_format": "{post_id}-{media_id}-{date}-{file_name}.{ext}",