### PR TITLE
Fix type error in main_helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,9 @@ Thumbs.db:encryptable
 ehthumbs.db
 ehthumbs_vista.db
 
+### Mac ###
+.DS_Store
+
 # Dump file
 *.stackdump
 

--- a/classes/make_settings.py
+++ b/classes/make_settings.py
@@ -12,6 +12,7 @@ def fix(config={}):
             for key2, value2 in value.items():
                 for key3, settings in value2.items():
                     if key3 == "settings":
+                        settings["text_length"] = int(settings["text_length"])
                         re = settings.pop("download_paths", None)
                         if re:
                             settings["download_directories"] = re

--- a/helpers/main_helper.py
+++ b/helpers/main_helper.py
@@ -235,7 +235,7 @@ def reformat(prepared_format, unformatted):
     date = prepared_format.date
     text = prepared_format.text
     value = "Free"
-    maximum_length = int(prepared_format.maximum_length)
+    maximum_length = prepared_format.maximum_length
     post_id = "" if post_id is None else str(post_id)
     media_id = "" if media_id is None else str(media_id)
     extra_count = 0

--- a/helpers/main_helper.py
+++ b/helpers/main_helper.py
@@ -235,7 +235,7 @@ def reformat(prepared_format, unformatted):
     date = prepared_format.date
     text = prepared_format.text
     value = "Free"
-    maximum_length = prepared_format.maximum_length
+    maximum_length = int(prepared_format.maximum_length)
     post_id = "" if post_id is None else str(post_id)
     media_id = "" if media_id is None else str(media_id)
     extra_count = 0


### PR DESCRIPTION
Running via docker, getting the following error.

> File "/usr/src/app/helpers/main_helper.py", line 272, in reformat
>     maximum_length = maximum_length - int(directory_count+path_count+extra_count)
> TypeError: unsupported operand type(s) for -: 'str' and 'int'

Seems like `prepared_format.maximum_length` is a string.