### PR TITLE
Correct max path length calculation

### DIFF
--- a/helpers/main_helper.py
+++ b/helpers/main_helper.py
@@ -272,7 +272,7 @@ def reformat(prepared_format, unformatted):
     path = path.replace("{date}", date)
     directory_count = len(directory)
     path_count = len(path)
-    maximum_length = maximum_length - (directory_count+path_count+extra_count)
+    maximum_length = maximum_length - (directory_count+path_count-extra_count)
     text_length = text_length if text_length < maximum_length else maximum_length
     if has_text:
         filtered_text = text[:text_length]


### PR DESCRIPTION
Since `path` contains the `{text}` placeholder which will be replaced, these 6 characters don't count against the limit