### PR TITLE
Reduce docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3-slim
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
By using the `-slim` python image we can reduce the final docker image size by ~800MB

```
REPOSITORY                     TAG                 IMAGE ID            CREATED             SIZE
ofd                            v6.2.4-slim         ce1c405368ee        32 minutes ago      211MB
ofd                            v6.2.4              f6c8817f33a8        27 hours ago        981MB
```