### PR TITLE
Update `prepare_reformat` to pass `preview` data. Fixes #782

### DIFF
--- a/classes/prepare_metadata.py
+++ b/classes/prepare_metadata.py
@@ -369,6 +369,7 @@ class prepare_reformat(object):
         self.text_length = option.get('text_length', self.maximum_length)
         self.directory = option.get(
             'directory')
+        self.preview = option.get('preview')
         if not keep_vars:
             for key, value in self:
                 print


### PR DESCRIPTION
```
File "/usr/src/app/helpers/main_helper.py", line 322, in reformat
    if not prepared_format.preview:
AttributeError: 'prepare_reformat' object has no attribute 'preview'
```

I traced this back to the `prepare_format` function not passing through the `preview` attribute to the `reformat` function. I just added it the same way 'directory' and 'date_format' are used and this fixed the problem for me.

Closes #782 