### PR TITLE
dirty fix to https://github.com/DIGITALCRIMINAL/OnlyFans/issues/789, …

### DIFF
--- a/apis/onlyfans/onlyfans.py
+++ b/apis/onlyfans/onlyfans.py
@@ -423,7 +423,16 @@ class create_subscription():
         links = self.links.Archived.Posts
         if links:
             results = api_helper.scrape_check(links, self.session_manager, api_type)
-        self.scraped.Archived.Posts = results
+        try:
+            self.scraped.Archived.Posts = results
+        except AttributeError:
+            # dirty fix to #789
+            class archived_types(content_types):
+                def __init__(self) -> None:
+                    self.Posts = []
+
+            self.scraped.Archived = archived_types()
+            self.scraped.Archived.Posts = results
         return results
 
     def get_archived(self, api):


### PR DESCRIPTION
…just "adding" the archived attribute back in the same way like it is done in the creation of the content_type class.

could create more issues, cant spot the issue source either (do not understand the workings fully yet).

But it could be related to modules/onlyfans.py, line 712 or apis/onlyfans/onlyfans.py, line 88, since these are the only places i found the code deleting attributes (but the first example should occur only after the error from the issue throws and the second is not related to the subscription class AFAIK), means the error could be caused by the code deleting .Archived from content_types or rather .scraped