### PR TITLE
Don't quit when a singe onlyfans scrapping item fails

### DIFF
--- a/modules/onlyfans.py
+++ b/modules/onlyfans.py
@@ -7,6 +7,8 @@ from typing import Union
 from apis.onlyfans.onlyfans import auth_details, content_types, create_auth, create_subscription, media_types, start
 from classes.prepare_metadata import create_metadata, format_content, prepare_reformat
 import os
+import sys
+import traceback
 from datetime import datetime, timedelta
 from itertools import chain, product
 from urllib.parse import urlparse
@@ -144,10 +146,14 @@ def start_datascraper(api: start, identifier, site_name, choice_type=None):
         item["api_array"]["username"] = username
         item["api_array"]["subscription"] = subscription
         api_type = item["api_type"]
-        results = prepare_scraper(
-            api, site_name, item)
+        try:
+            results = prepare_scraper(
+                api, site_name, item)
+        except:
+            print("Scraping error:")
+            traceback.print_exc(file=sys.stdout)
         print
-    print("Scrape Completed"+"\n")
+    print("Scrape Finished"+"\n")
     return [True, subscription]
 
 


### PR DESCRIPTION
There have been a lot of issues (and responsive fixes 👏) lately with onlyfans scraping. I thought it would be nice though, if a problem with one model wouldn't break downloading of all the others.

The try/catch here is a naive attempt, a problem with a single `Archive` type post will bail the rest of that models archives, but the `Post`s can still work. It would be nice to put a try/catch around each post too? But I guess ideally there won't be issues all the time.

There is similar code structure in the other scrapers (patreon for example), but I don't use those so not sure if it's worthwhile also doing this in those.

One of the bigger downsides is this will "silently" error out now, so I (and others) would have to manually review the logs of each run to see of there were any actual errors. Maybe there's a way to bubble up the fact that an error happened so the script can exit with a failure code?