### PR TITLE
Dirty fix for Fix KeyError: 'filename' & Add link to the cookie helper plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ All issues about auth errors will be closed automatically. It's spam at this poi
 
 Note: If active is set to False, the script will ignore the profile.
 
+**You can also use [this browser extension](https://github.com/M-rcus/OnlyFans-Cookie-Helper) to automatically get the AUTH JSON**
+
 # USAGE
 
 `python start_ofd.py` or double click `start_ofd.py`

--- a/modules/onlyfans.py
+++ b/modules/onlyfans.py
@@ -872,7 +872,7 @@ def getValueIfKey(key, dictv):
         return dictv[key]
     else:
         unknowncount+=1
-        return 'unknown{unkowncount}'
+        return 'unknown{unknowncount}'
 
 def media_scraper(results, api: start, subscription: create_subscription, formatted_directories, username, api_type, parent_type="", print_output=True):
     new_set = {}

--- a/modules/onlyfans.py
+++ b/modules/onlyfans.py
@@ -865,7 +865,14 @@ def compare_metadata(new_metadata: create_metadata, old_metadata: create_metadat
     return new_metadata
 
 # Scrapes the API for content
-
+unknowncount = 0
+def getValueIfKey(key, dictv):
+    global unknowncount
+    if key in dictv:
+        return dictv[key]
+    else:
+        unknowncount+=1
+        return 'unknown{unkowncount}'
 
 def media_scraper(results, api: start, subscription: create_subscription, formatted_directories, username, api_type, parent_type="", print_output=True):
     new_set = {}
@@ -1073,7 +1080,7 @@ def media_scraper(results, api: start, subscription: create_subscription, format
                             if not medias:
                                 medias = post.get("media",[])
                             found_medias = [x for x in medias
-                                            if x["filename"] == new_media["filename"]]
+                                            if getValueIfKey("filename", x) == getValueIfKey("filename", new_media)]
                             if found_medias:
                                 for found_media in found_medias:
                                     found_media["linked"] = api_type


### PR DESCRIPTION
I added a link to help new users get their auth token information using a browser extension developed by @M-rcus