### PR TITLE
Fix selenium auth with firefox

### DIFF
--- a/extras/OFLogin/start_ofl.py
+++ b/extras/OFLogin/start_ofl.py
@@ -3,8 +3,7 @@ from seleniumwire import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions
-from selenium.webdriver.firefox.options import Options as FirefoxOptions
-from selenium.webdriver.firefox.firefox_profile import FirefoxProfile
+from selenium.webdriver import FirefoxOptions, FirefoxProfile
 from user_agent import generate_user_agent
 
 

--- a/extras/OFLogin/start_ofl.py
+++ b/extras/OFLogin/start_ofl.py
@@ -3,6 +3,8 @@ from seleniumwire import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions
+from selenium.webdriver.firefox.options import Options as FirefoxOptions
+from selenium.webdriver.firefox.firefox_profile import FirefoxProfile
 from user_agent import generate_user_agent
 
 
@@ -24,9 +26,9 @@ def launch_browser(headers=None, user_agent=None, proxy=None, browser_type="Fire
             driver_path for driver_path in driver_paths if os.path.exists(driver_path)]
         if found_paths:
             driver_path = found_paths[0]
-            opts = webdriver.FirefoxOptions()
-            # opts.add_argument("--headless")
-            profile = webdriver.FirefoxProfile()
+            opts = FirefoxOptions()
+            # opts.headless = True
+            profile = FirefoxProfile()
             if not user_agent:
                 user_agent = generate_user_agent()
             profile.set_preference("general.useragent.override", user_agent)


### PR DESCRIPTION
Fixes #945, #952.

from looking at the original error, seleniumwire doesn't expose `FirefoxOptions` or `FirefoxProfile`
https://github.com/wkeeling/selenium-wire/blob/625f545fe331e55fa1696344ecfa5a4a153cfb2b/seleniumwire/webdriver.py

using the suggested methods from selenium seems to work
https://www.selenium.dev/documentation/en/driver_idiosyncrasies/driver_specific_capabilities/#firefox

also i got this working with the latest version of geckodriver so i'm not sure why it's suggested to remain locked in with 0.27.0