### PR TITLE
Added ability to export csv of links without downloading images

### DIFF
--- a/classes/make_settings.py
+++ b/classes/make_settings.py
@@ -225,6 +225,8 @@ class config(object):
                             'auto_scrape_apis', True)
                         self.browser = browser(option.get(
                             'browser', {}))
+                        self.csv_export_only = option.get(
+                            'csv_export_only', False)
                         self.jobs = jobs(option.get(
                             'jobs', {}))
                         self.download_directories = option.get(


### PR DESCRIPTION
Issue #1053 Implemented for OnlyFans. Figured I'd create a review in case you are interested in pulling it back in. If not, feel free to reject it and I'll keep it in the fork.

Skips image download and instead exports scrubbed links from SQLite database into a csv/newline delimited list of links.