### PR TITLE
Fix for Issue 1093 - half of each account's subscriptions are not scraped

### DIFF
--- a/apis/onlyfans/onlyfans.py
+++ b/apis/onlyfans/onlyfans.py
@@ -673,7 +673,7 @@ class start():
         results = api_helper.json_request(link=link, session=session)
         return results
 
-    def get_subscriptions(self, resume=None, refresh=True, identifiers: list = [], extra_info=True, limit=20, offset=0) -> list[Union[create_subscription, None]]:
+    def get_subscriptions(self, resume=None, refresh=True, identifiers: list = [], extra_info=True, limit=10, offset=0) -> list[Union[create_subscription, None]]:
         authed = self.auth
         if not authed.active:
             return []


### PR DESCRIPTION
OF changed their API backend to use a page size of 10, regardless of the parameter value specified.
The fix is to change the limit to 10, so that the calculation for number of calls to make is correct.