### PR TITLE
Fix fallback to source link

### DIFF
--- a/modules/onlyfans.py
+++ b/modules/onlyfans.py
@@ -965,7 +965,7 @@ def media_scraper(results, authed: create_auth, subscription: create_subscriptio
                                 video_quality_json = video_quality_json.removesuffix(
                                     "p")
                                 if quality == video_quality_json:
-                                    if link:
+                                    if quality_link:
                                         link = quality_link
                                         break
                                     print


### PR DESCRIPTION
I noticed that I can't download certain files when setting quality to 720p. Turns out that for files which don't have a 720p URL, the fallback source URL gets overwritten. Since there's quite a bit of logic to fetch the source URL independent of the quality setting, I assume this is a bug.