### PR TITLE
bump `tqdm` version

### DIFF
--- a/extras/OFRenamer/start_ofr.py
+++ b/extras/OFRenamer/start_ofr.py
@@ -138,7 +138,7 @@ async def fix_directories(
     # tasks = pool.starmap(fix_directories2, product(posts, [media_db]))
     tasks = [asyncio.ensure_future(fix_directories2(post,media_db)) for post in posts]
     settings = {"colour": "MAGENTA", "disable": False}
-    delete_rows = await tqdm.gather(tasks, **settings)
+    delete_rows = await tqdm.gather(*tasks, **settings)
     delete_rows = list(chain(*delete_rows))
     for delete_row in delete_rows:
         database_session.query(folder.media_table).filter(

--- a/modules/onlyfans.py
+++ b/modules/onlyfans.py
@@ -398,7 +398,7 @@ async def paid_content_scraper(api: start, identifiers=[]):
                     ),
                 )
                 settings = {"colour": "MAGENTA"}
-                unrefined_set = await tqdm.gather(tasks, **settings)
+                unrefined_set = await tqdm.gather(*tasks, **settings)
                 new_metadata = main_helper.format_media_set(unrefined_set)
                 new_metadata = new_metadata["content"]
                 if new_metadata:
@@ -820,7 +820,7 @@ async def prepare_scraper(authed: create_auth, site_name, item):
             ),
         )
         settings = {"colour": "MAGENTA"}
-        unrefined_set = await tqdm.gather(tasks, **settings)
+        unrefined_set = await tqdm.gather(*tasks, **settings)
     unrefined_set = [x for x in unrefined_set]
     new_metadata = main_helper.format_media_set(unrefined_set)
     metadata_path = os.path.join(formatted_metadata_directory, "user_data.db")

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ jsonpickle
 ujson
 sqlalchemy==1.4.20
 alembic
-tqdm
+tqdm>=4.62.0
 selenium
 selenium-wire==2.1.2
 user_agent


### PR DESCRIPTION
New `tqdm.asyncio.tqdm.gather` syntax ([`tqdm>=4.62.0`](https://tqdm.github.io/releases/#v4620-2021-07-30) <- https://github.com/tqdm/tqdm/pull/1209 <- https://github.com/tqdm/tqdm/pull/1212)