### PR TITLE
Filtering out posts that the user has reported

### DIFF
--- a/apis/onlyfans/classes/create_user.py
+++ b/apis/onlyfans/classes/create_user.py
@@ -298,7 +298,9 @@ class create_user:
         results = await api_helper.scrape_endpoint_links(
             links, self.session_manager, api_type
         )
-        final_results = [create_post(x, self) for x in results]
+        # Filter out posts that are reported by the user as these will not have content
+        filtered_results = filter(lambda opt: "isReportedByMe" in opt and opt["isReportedByMe"] is False, results)
+        final_results = [create_post(x, self) for x in filtered_results]
         self.temp_scraped.Posts = final_results
         return final_results
 

--- a/apis/onlyfans/classes/create_user.py
+++ b/apis/onlyfans/classes/create_user.py
@@ -299,7 +299,7 @@ class create_user:
             links, self.session_manager, api_type
         )
         # Filter out posts that are reported by the user as these will not have content
-        filtered_results = filter(lambda opt: "isReportedByMe" in opt and opt["isReportedByMe"] is False, results)
+        filtered_results = list(filter(lambda opt: not ("isReportedByMe" in opt and opt["isReportedByMe"]), results))
         final_results = [create_post(x, self) for x in filtered_results]
         self.temp_scraped.Posts = final_results
         return final_results


### PR DESCRIPTION
I had accidentally reported a post.  Now that post errors out with a `self.author = create_user.create_user(option["author"])
KeyError: 'author`.  It appears that most of the content is stripped out of a post when that post is reported.  

This change filters out posts that have the isReportedByMe flag set to True before calling create_post.